### PR TITLE
Adopt XT's EVS 1.0 to Android 11

### DIFF
--- a/app/Android.bp
+++ b/app/Android.bp
@@ -48,7 +48,6 @@ cc_binary {
         "liblog",
         "libutils",
         "libui",
-        "libhidltransport",
         "libEGL",
         "libGLESv2",
         "libhardware",

--- a/app/WindowSurface.cpp
+++ b/app/WindowSurface.cpp
@@ -19,7 +19,7 @@
 #include <gui/SurfaceComposerClient.h>
 #include <gui/ISurfaceComposer.h>
 #include <gui/Surface.h>
-#include <ui/DisplayInfo.h>
+#include <ui/DisplayConfig.h>
 
 using namespace android;
 
@@ -40,27 +40,19 @@ WindowSurface::WindowSurface() {
         return;
     }
 
-    DisplayInfo mainDpyInfo;
-    err = SurfaceComposerClient::getDisplayInfo(mainDpy, &mainDpyInfo);
+    DisplayConfig displayConfig;
+    err = SurfaceComposerClient::getActiveDisplayConfig(mainDpy, &displayConfig);
     if (err != NO_ERROR) {
         fprintf(stderr, "ERROR: unable to get display characteristics\n");
         return;
     }
 
-    uint32_t width, height;
-    if (mainDpyInfo.orientation != DISPLAY_ORIENTATION_0 &&
-            mainDpyInfo.orientation != DISPLAY_ORIENTATION_180) {
-        // rotated
-        width = mainDpyInfo.h;
-        height = mainDpyInfo.w;
-    } else {
-        width = mainDpyInfo.w;
-        height = mainDpyInfo.h;
-    }
-
     sp<SurfaceControl> sc = surfaceComposerClient->createSurface(
-            String8("Benchmark"), width, height,
-            PIXEL_FORMAT_RGBX_8888, ISurfaceComposerClient::eOpaque);
+            String8("Benchmark"),
+            displayConfig.resolution.width,
+            displayConfig.resolution.height,
+            PIXEL_FORMAT_RGBX_8888,
+            ISurfaceComposerClient::eOpaque);
     if (sc == NULL || !sc->isValid()) {
         fprintf(stderr, "Failed to create SurfaceControl\n");
         return;

--- a/manager/Android.bp
+++ b/manager/Android.bp
@@ -29,7 +29,6 @@ cc_binary {
         "libutils",
         "libui",
         "libhidlbase",
-        "libhidltransport",
         "libhardware",
         "android.hardware.automotive.evs@1.0",
     ],

--- a/sampleDriver/Android.bp
+++ b/sampleDriver/Android.bp
@@ -41,7 +41,6 @@ cc_binary {
         "liblog",
         "libutils",
         "libui",
-        "libhidltransport",
         "libEGL",
         "libGLESv2",
         "libgui",

--- a/sampleDriver/GlWrapper.cpp
+++ b/sampleDriver/GlWrapper.cpp
@@ -21,7 +21,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 
-#include <ui/DisplayInfo.h>
+#include <ui/DisplayConfig.h>
 #include <ui/GraphicBuffer.h>
 #include <ui/GraphicBufferAllocator.h>
 #include <ui/GraphicBufferMapper.h>
@@ -240,22 +240,15 @@ bool GlWrapper::initialize() {
         fprintf(stderr, "ERROR: no internal display\n");
         return false;
     }
-    DisplayInfo mainDpyInfo;
-    err = SurfaceComposerClient::getDisplayInfo(mainDpy, &mainDpyInfo);
+    DisplayConfig displayConfig;
+    err = SurfaceComposerClient::getActiveDisplayConfig(mainDpy, &displayConfig);
     if (err != NO_ERROR) {
         ALOGE("ERROR: unable to get display characteristics");
         return false;
     }
 
-    if (mainDpyInfo.orientation != DISPLAY_ORIENTATION_0 &&
-        mainDpyInfo.orientation != DISPLAY_ORIENTATION_180) {
-        // rotated
-        mWidth = mainDpyInfo.h;
-        mHeight = mainDpyInfo.w;
-    } else {
-        mWidth = mainDpyInfo.w;
-        mHeight = mainDpyInfo.h;
-    }
+    mWidth = displayConfig.resolution.width;
+    mHeight = displayConfig.resolution.height;
 
     mFlingerSurfaceControl = mFlinger->createSurface(
             String8("Evs Display"), mWidth, mHeight,


### PR DESCRIPTION
These changes allows to build and run XT's EVS on A11:
* Remove hidltransport
* Use DisplayConfig instead of DisplayInfo
* Do not check orientation as not relevant for our usage

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>