### PR TITLE
evs: fix compilation for android 17

### DIFF
--- a/apps/default/src/Utils.cpp
+++ b/apps/default/src/Utils.cpp
@@ -16,6 +16,8 @@
 
 #include "Utils.h"
 
+#include <algorithm>
+
 #include <aidl/android/hardware/automotive/evs/BufferDesc.h>
 #include <aidlcommonsupport/NativeHandle.h>
 #include <android-base/logging.h>

--- a/sampleDriver/aidl/include/ConfigManager.h
+++ b/sampleDriver/aidl/include/ConfigManager.h
@@ -25,6 +25,8 @@
 
 #include <tinyxml2.h>
 
+#include <condition_variable>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>


### PR DESCRIPTION
Add missing includes to compile for the Android 17.